### PR TITLE
sleep before removing RegionsManager output

### DIFF
--- a/sc4mpserver.py
+++ b/sc4mpserver.py
@@ -1681,6 +1681,10 @@ class RegionsManager(th.Thread):
 								for directory in os.listdir(path):
 									if (directory in self.outputs.keys()):
 										shutil.rmtree(os.path.join(path, directory))
+										
+										# sleep to allow RequestHandler.save() time to check for success
+										time.sleep(2 * SC4MP_DELAY)
+										
 										self.outputs.pop(directory)
 							except Exception as e:
 								pass


### PR DESCRIPTION
I believe the cause of the issue is that the `RegionsManager` removes the save key from the outputs before  `RequestsHandler.save()` can verify that it succeeded.  That thread would then get stuck in its while loop indefinitely.