### PR TITLE
Update ServerList 

### DIFF
--- a/sc4mpserver.py
+++ b/sc4mpserver.py
@@ -16,9 +16,11 @@ import sys
 import threading as th
 import time
 import traceback
+
+from collections import deque
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Optional
+from typing import Iterable
 
 SC4MP_VERSION = "0.4.0"
 
@@ -2143,8 +2145,8 @@ class RequestHandler(th.Thread):
 		host = c.getpeername()[0]
 		port = int(port)
 		server = (host, port)
-		if (not server in sc4mp_server_list.server_queue) and (not len(sc4mp_server_list.server_queue) > sc4mp_server_list.SERVER_LIMIT):
-			sc4mp_server_list.server_queue.append(server)
+		if len(sc4mp_server_list.server_queue) < sc4mp_server_list.SERVER_LIMIT:
+			sc4mp_server_list.server_queue.enqueue(server, left=True) # skip to the front of the queue
 
 
 	def server_list(self, c):
@@ -2264,6 +2266,37 @@ class RequestHandler(th.Thread):
 		c.send(b'done')
 
 
+class ServerQueue:
+	"""
+	Queue for server scanning that implements membership check before enqueuing.
+	Can optionally enqueue to the front (left) of the queue.
+	The queue contains (host, port) tuples.
+	"""
+
+	def __init__(self, servers: Iterable[tuple[str,int]]) -> None:
+		self._queue = deque(servers)
+
+	def __len__(self):
+		return len(self._queue)
+
+	def enqueue(self, server: tuple[str,int], left=False) -> None:
+		"""
+		Adds a server to the queue, defaulting to the tail end (right).
+		left=True adds the server to the front of the queue.
+		Servers are only enqueued if they are not already in queue.
+		"""
+		if server in self._queue:
+			return
+		if left:
+			self._queue.appendleft(server)
+			return
+		self._queue.append(server)
+
+	def dequeue(self) -> tuple[str,int]:
+		"""Gets the server at the front of the queue"""
+		return self._queue.popleft()
+
+
 class ServerList(th.Thread):
 
 
@@ -2282,7 +2315,7 @@ class ServerList(th.Thread):
 		self.servers["root"]["host"] = SC4MP_SERVERS[0][0]
 		self.servers["root"]["port"] = SC4MP_SERVERS[0][1]
 
-		self.server_queue = SC4MP_SERVERS.copy()
+		self.server_queue = ServerQueue(SC4MP_SERVERS.copy())
 
 
 	def run(self):
@@ -2304,13 +2337,13 @@ class ServerList(th.Thread):
 					server_id = random.choice(list(self.servers.keys()))
 					if (self.servers[server_id]["host"], self.servers[server_id]["port"]) not in SC4MP_SERVERS:
 						self.servers.pop(server_id)
-	
+
 				if len(self.server_queue) > 0 or len(self.servers) > 0:
 
 					# Get the next server
 					server = None
 					if len(self.server_queue) > 0:
-						server = self.server_queue.pop(0)
+						server = self.server_queue.dequeue()
 					else:
 						server_id = random.choice(list(self.servers.keys()))
 						server_entry = self.servers.pop(server_id)
@@ -2418,12 +2451,12 @@ class ServerList(th.Thread):
 		s.send(b"server_list")
 		size = int(s.recv(SC4MP_BUFFER_SIZE).decode())
 		s.send(SC4MP_SEPARATOR)
-		for count in range(size):
+		for _ in range(size):
 			host = s.recv(SC4MP_BUFFER_SIZE).decode()
 			s.send(SC4MP_SEPARATOR)
 			port = int(s.recv(SC4MP_BUFFER_SIZE).decode())
 			s.send(SC4MP_SEPARATOR)
-			self.server_queue.append((host, port))
+			self.server_queue.enqueue((host, port))
 
 
 # Exceptions

--- a/sc4mpserver.py
+++ b/sc4mpserver.py
@@ -2311,9 +2311,7 @@ class ServerList(th.Thread):
 		except:
 			self.servers = {}
 
-		self.servers["root"] = {}
-		self.servers["root"]["host"] = SC4MP_SERVERS[0][0]
-		self.servers["root"]["port"] = SC4MP_SERVERS[0][1]
+		self.servers["root"] = {"host": SC4MP_SERVERS[0][0], "port": SC4MP_SERVERS[0][1]}
 
 		self.server_queue = ServerQueue(SC4MP_SERVERS.copy())
 
@@ -2369,15 +2367,12 @@ class ServerList(th.Thread):
 								print("[WARNING] Resolving server_id conflict...")
 								if self.ping(old_server) is None:
 									print("[WARNING] - keeping the new server!")
-									self.servers[server_id]["host"] = server[0]
-									self.servers[server_id]["port"] = server[1]
+									self.servers[server_id] = {"host": server[0], "port": server[1]}
 								else:
 									print("[WARNING] - keeping the old server!")
 						else:
 							print("- adding \"" + server_id + "\" to our server list")
-							self.servers[server_id] = {}
-							self.servers[server_id]["host"] = server[0]
-							self.servers[server_id]["port"] = server[1]
+							self.servers[server_id] = {"host": server[0], "port": server[1]}
 
 						# Request to be added to the server's server list
 						print("- requesting to be added to their server list...")

--- a/sc4mpserver.py
+++ b/sc4mpserver.py
@@ -2444,13 +2444,8 @@ class ServerList(th.Thread):
 		"""TODO"""
 		s = self.create_socket(server)
 		s.send(b"server_list")
-		size = int(s.recv(SC4MP_BUFFER_SIZE).decode())
-		s.send(SC4MP_SEPARATOR)
-		for _ in range(size):
-			host = s.recv(SC4MP_BUFFER_SIZE).decode()
-			s.send(SC4MP_SEPARATOR)
-			port = int(s.recv(SC4MP_BUFFER_SIZE).decode())
-			s.send(SC4MP_SEPARATOR)
+		servers = recv_json(s)
+		for host, port in servers:
 			self.server_queue.enqueue((host, port))
 
 


### PR DESCRIPTION
Fixes #24 by implementing a ServerQueue class using a deque from Python collections.  The queue will not allow duplicates to be added.  It's a double ended queue, and so allows for elements to be inserted at the front of the queue, which is used by the add_server request so that these sync requests hopefully propagate quicker.

Changes the server_list method to receive the server list as json.