### PR TITLE
80-fix-unicode-decode-error

### DIFF
--- a/core/dbpf.py
+++ b/core/dbpf.py
@@ -26,7 +26,7 @@ class DBPF:
 			self.file.seek(self.offset)
 
 		# Read the identifier
-		self.identifier = self.file.read(4).decode()		# Always "DBPF"
+		self.identifier = self.file.read(4).decode('latin-1')		# Always "DBPF"
 		if self.require_identifier and self.identifier != "DBPF":
 			raise Exception()
 
@@ -210,7 +210,7 @@ class DBPF:
 			file = self.file
 		if length is None:
 			length = struct.unpack("<L", file.read(4))[0]
-		return file.read(length).decode()
+		return file.read(length).decode('latin-1')
 
 
 	def read_nullstring(self, file=None):
@@ -222,7 +222,7 @@ class DBPF:
 			if byte == b"\x00":
 				return text
 			else:
-				text += byte.decode()
+				text += byte.decode('latin-1')
 
 
 	def read_ID(self, file=None):


### PR DESCRIPTION
## Summary
Fixes UnicodeDecodeError when parsing SimCity 4 savegames containing extended ASCII characters.

## Problem
Server crashed with error: `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa1 in position 4: invalid start byte`

SimCity 4 (2003) uses Windows-1252/Latin-1 encoding for text in savegames, not UTF-8. The `.decode()` calls in `core/dbpf.py` defaulted to UTF-8, causing crashes on certain savegames.

## Changes
- **Line 29:** DBPF identifier decoding - `decode()` → `decode('latin-1')`
- **Line 213:** `read_unistr()` string decoding - `decode()` → `decode('latin-1')`
- **Line 225:** `read_nullstring()` byte decoding - `decode()` → `decode('latin-1')`

## Why Latin-1?
- Maps **all** byte values 0-255 to Unicode (never fails)
- Compatible with Windows-1252 for most characters
- Standard for legacy Windows applications
- SimCity 4 savegame format uses this encoding

## Test Plan
- [x] Python syntax validation passed
- [ ] Test with savegames containing extended ASCII characters
- [ ] Test with standard savegames
- [ ] Verify mayor names, city names display correctly

Fixes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)