### PR TITLE
81-fix-prevent-multiple

### DIFF
--- a/sc4mpserver.py
+++ b/sc4mpserver.py
@@ -271,8 +271,7 @@ def prevent_multiple():
 						o_p_c = None
 
 					if other_process_creation == o_p_c:
-						if subprocess.call(f"TASKKILL /F /PID {other_process_pid}", shell=True) != 0:
-							raise ServerException("`TASKKILL` did not return exit code 0.")
+						subprocess.call(f"TASKKILL /F /PID {other_process_pid}", shell=True)
 
 			this_process_pid = os.getpid()
 			this_process_creation = datetime.strftime(get_process_creation_time(this_process_pid), DATETIME_FORMAT)


### PR DESCRIPTION
## Summary

Fixes #81 - Server sometimes refuses to start even when no duplicate process exists.

## Problem

The `prevent_multiple()` function raises an exception when TASKKILL returns a non-zero exit code. However, TASKKILL often fails when the process is already gone, causing false positives that block server startup.

## Solution

Remove the exception check. Simply call TASKKILL and continue with startup regardless of the exit code.

**Changed:** Lines 274-275 in sc4mpserver.py

**Before:**
```python
if subprocess.call(f"TASKKILL /F /PID {other_process_pid}", shell=True) != 0:
    raise ServerException("`TASKKILL` did not return exit code 0.")
```

**After:**
```python
subprocess.call(f"TASKKILL /F /PID {other_process_pid}", shell=True)
```

## Testing

- Python 3.8 syntax validation passed
- Minimal change: 1 line added, 2 lines removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Claude Code**