### PR TITLE
fix-util-typos

### DIFF
--- a/core/util.py
+++ b/core/util.py
@@ -28,7 +28,7 @@ except ImportError:
 	pass
 
 
-#TODO add MacOS compatability
+#TODO add MacOS compatibility
 def process_count(process_name):
 
 	if platform.system() == "Windows":
@@ -213,8 +213,8 @@ def update_server_list(maximum=100):
 	with server_file.open("r") as file:
 		lines = file.readlines()
 	
-	# If the file has more than `maxiumum`, slice the list to keep only the 
-	# last `maxiumum` lines
+	# If the file has more than `maximum`, slice the list to keep only the
+	# last `maximum` lines
 	if len(lines) > maximum:
 
 		lines = lines[-maximum:]


### PR DESCRIPTION
## Summary

Fixes spelling errors in comments in core/util.py.

## Changes

**Line 31:** TODO comment
- Before: "#TODO add MacOS **compatability**"
- After: "#TODO add MacOS **compatibility**"

**Lines 216-217:** Function comment
- Before: "If the file has more than `**maxiumum**`, slice the list to keep only the last `**maxiumum**` lines"
- After: "If the file has more than `**maximum**`, slice the list to keep only the last `**maximum**` lines"

## Testing

- Python 3.8 syntax validation passed
- Minimal change: 1 file, 3 lines modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Claude Code**