### PR TITLE
fix-config-typos

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -42,11 +42,11 @@ class Config:
 						except (configparser.NoSectionError, configparser.NoOptionError):
 							print(f"[WARNING] Option \"{item_name}\" missing from section \"{section_name}\" of the config file at \"{self.PATH}\". Using default value.")
 						except Exception as e:
-							self.show_error("An error occured while reading a config item.", no_ui=True)
+							self.show_error("An error occurred while reading a config item.", no_ui=True)
 				except Exception as e:
-					self.show_error("An error occured while reading a config section.", no_ui=True)
+					self.show_error("An error occurred while reading a config section.", no_ui=True)
 		except Exception as e:
-			self.show_error("An error occured while reading the config.", no_ui=True)
+			self.show_error("An error occurred while reading the config.", no_ui=True)
 
 		# Update config file
 		self.update()


### PR DESCRIPTION
## Summary

Fixes spelling errors in error messages in core/config.py.

## Changes

All three error messages had the same typo:

**Line 45:** "An error **occured** while reading a config item." -> "An error **occurred** while reading a config item."

**Line 47:** "An error **occured** while reading a config section." -> "An error **occurred** while reading a config section."

**Line 49:** "An error **occured** while reading the config." -> "An error **occurred** while reading the config."

## Testing

- Python 3.8 syntax validation passed
- Minimal change: 1 file, 3 lines modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Claude Code**